### PR TITLE
Allow to set an recur of none

### DIFF
--- a/ultralist/input_parser.go
+++ b/ultralist/input_parser.go
@@ -175,14 +175,17 @@ func (p *InputParser) Parse(input string) (*Filter, error) {
 			filter.HasRecur = true
 			filter.Recur = r.FindString(word)[6:]
 
+			r := &Recurrence{}
+
+			if !r.ValidRecurrence(filter.Recur) {
+				return filter, fmt.Errorf("I could not understand the recurrence you gave me: '%s'", filter.Recur)
+			}
+
+			// a Recur of none is "" in the Todo store, lets set that now
 			if filter.Recur == "none" {
 				filter.Recur = ""
 			}
 
-			r := &Recurrence{}
-			if !r.ValidRecurrence(filter.Recur) {
-				return filter, fmt.Errorf("I could not understand the recurrence you gave me: '%s'", filter.Recur)
-			}
 		}
 
 		r, _ = regexp.Compile(`until:.*$`)

--- a/ultralist/recurrence.go
+++ b/ultralist/recurrence.go
@@ -10,6 +10,7 @@ const (
 	Weekly   = "weekly"
 	Monthly  = "monthly"
 	Yearly   = "yearly"
+	None     = "none"
 )
 
 // Recurrence struct contains the logic for dealing with recurring todos.
@@ -19,6 +20,7 @@ type Recurrence struct{}
 func (r *Recurrence) ValidRecurrence(input string) bool {
 	switch input {
 	case
+		None,
 		Daily,
 		Weekdays,
 		Weekly,


### PR DESCRIPTION
This should fix https://github.com/ultralist/ultralist/issues/254

The problem comes down, setting none to "", before validating. 

I have moved the validation above, allowed `none` to  be a valid occurrence.

this will allow `recur:none` but not `recur:`