### PR TITLE
Fix typo in cmd/archive.go

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -10,7 +10,7 @@ import (
 func init() {
 	var (
 		archiveCmdExample = `
-  To arvhive a todo with id 33:
+  To archive a todo with id 33:
     ultralist archive 33
     ultralist ar 33
 


### PR DESCRIPTION
Hi, very nice tool, I'm a user for years now!

I just spotted a typo in the command line tool which I suggest to fix.