### PR TITLE
Show the help text when zero arguments given to the edit command

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -41,6 +41,11 @@ func init() {
 		Long:    longDesc,
 		Short:   editCmdDesc,
 		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				_ = cmd.Help()
+				return
+			}
+
 			todoID, err := strconv.Atoi(args[0])
 			if err != nil {
 				fmt.Printf("Could not parse todo ID: '%s'\n", args[0])


### PR DESCRIPTION
Hi,

This is a small quality of life change I hope you'll accept. I'm happy to do the work to apply this change more broadly too, if you'd prefer.

Previously, Ultralist would panic when given zero arguments. I think it should should show the help text instead.

Before

```
$ ultralist e
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/ultralist/ultralist/cmd.init.7.func1(0xc00022b080, {0x176feb0, 0x0, 0x0})
	github.com/ultralist/ultralist/cmd/edit.go:44 +0x21c
github.com/spf13/cobra.(*Command).execute(0xc00022b080, {0x176feb0, 0x0, 0x0})
	github.com/spf13/cobra@v1.0.0/command.go:846 +0x5f8
github.com/spf13/cobra.(*Command).ExecuteC(0x1736dc0)
	github.com/spf13/cobra@v1.0.0/command.go:950 +0x3ad
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.0.0/command.go:887
github.com/ultralist/ultralist/cmd.Execute()
	github.com/ultralist/ultralist/cmd/root.go:23 +0x25
main.main()
	github.com/ultralist/ultralist/main.go:8 +0x17
```

After

```
$ ./bin/ultralist e
Edits todos.

  You can edit all facets of a todo.

  Read the full docs at https://ultralist.io/docs/cli/managing_tasks/#editing-todos

Usage:
  ultralist edit [id] [flags]

Aliases:
  edit, e

Examples:
  To edit a todo's subject:
    ultralist edit 33 Meeting with @bob about +project
    ultralist e 33 Change the subject once again

  To edit just the due date, keeping the subject:
    ultralist edit 33 due:mon

  To remove a due date:
    ultralist edit 33 due none

  To edit a status
    ultralist edit 33 status:next

	To remove a status:
    ultralist edit 33 status:none

Flags:
  -h, --help   help for edit
```