### PR TITLE
Indent json when saving

### DIFF
--- a/ultralist/file_store.go
+++ b/ultralist/file_store.go
@@ -72,7 +72,7 @@ func (f *FileStore) Save(todos []*Todo) {
 		}
 	}
 
-	data, _ := json.Marshal(todos)
+	data, _ := json.MarshalIndent(todos, "", "  ")
 	if err := ioutil.WriteFile(f.GetLocation(), []byte(data), 0644); err != nil {
 		fmt.Println("Error writing json file", err)
 	}


### PR DESCRIPTION
First of all: very nice tool! I use it to track and manage my personal todo list.

Main use case: I'm storing my `.todos.json` in a git repo, indenting allows one to have human-readable cand comprehensible diffs and history.